### PR TITLE
Fix examples links

### DIFF
--- a/more/examples.md
+++ b/more/examples.md
@@ -7,19 +7,19 @@ This app works almost exactly like the hello world flutter app. But it will stor
 You can learn how to open Hive and use it's basic methods.
 
 * [Flutter Web demo](https://hivedb.github.io/hive/demos/counter/)
-* [Source Code](https://github.com/hivedb/hive/tree/master/examples/counter)
+* [Source Code](https://github.com/hivedb/samples/tree/master/counter)
 
 ## Hive To-Do
 
 This To-Do app has a generated TypeAdapter for the `Todo` class. It also stores the state of the app \(sorting order of todos\).
 
 * [Flutter Web demo](https://hivedb.github.io/hive/demos/todo/)
-* [Source Code](https://github.com/hivedb/hive/tree/master/examples/todo)
+* [Source Code](https://github.com/hivedb/samples/tree/master/todo)
 
 ## Hive SketchPad
 
 The sketchpad app uses a custom TypeAdapter to store the drawn path efficiently. It shows how even big data can be stored very fast.
 
 * [Flutter Web demo](https://hivedb.github.io/hive/demos/sketchpad/)
-* [Source Code](https://github.com/hivedb/hive/tree/master/examples/sketchpad)
+* [Source Code](https://github.com/hivedb/samples/tree/master/sketchpad)
 


### PR DESCRIPTION
Hey, great work on this project! While browsing the examples I noticed the examples have been moved to another repo. Fixed the links. :+1: 