### PR TITLE
Annotations don't require a semicolon

### DIFF
--- a/custom-objects/hive_object.md
+++ b/custom-objects/hive_object.md
@@ -7,10 +7,10 @@ Here is an example how to use `HiveObject`:
 ```dart
 @HiveType()
 class Person extends HiveObject {
-  @HiveField(0);
+  @HiveField(0)
   String name;
 
-  @HiveField(1);
+  @HiveField(1)
   int age;
 }
 ```


### PR DESCRIPTION
Leaving the semicolon will produce the following error.
> Expected a class member.