### PR TITLE
Examples of Box vs LazyBox incorrect

### DIFF
--- a/boxes/write.md
+++ b/boxes/write.md
@@ -29,7 +29,7 @@ box.put('key', 'value');
 print(box.get('key')); // value
 
 
-var lazyBox = await Hive.openBox('lazyBox');
+var lazyBox = await Hive.openLazyBox('lazyBox');
 
 lazyBox.put('key', 'value');
 print(lazyBox.get('key')); // null


### PR DESCRIPTION
the examples were identical in all but naming.
Looking at the class documentation I believe it should use 'openLazyBox' in the lazy box example.

NB this is literally my first look at Hive so I could be missing something