### PR TITLE
Correct documentation

### DIFF
--- a/advanced/lazy_box.md
+++ b/advanced/lazy_box.md
@@ -5,7 +5,7 @@ By default, the entire content of a box is stored in memory as soon as it is ope
 For larger boxes or very memory critical applications, it may be useful to load values lazily. When a lazy box is opened, all of its keys are read and stored in memory. Once you access a value, Hive knows its exact position on the disk and gets the value.
 
 ```dart
-var lazyBox = await Hive.openBox('myLazyBox', lazy: true) as LazyBox;
+var lazyBox = await Hive.openLazyBox('myLazyBox');
 
 var value = await lazyBox.get('lazyVal');
 ```
@@ -13,6 +13,6 @@ var value = await lazyBox.get('lazyVal');
 To get an already opened lazy box call:
 
 ```dart
-var lazyBox = Hive.box('myLazyBox') as LazyBox;
+var lazyBox = Hive.lazyBox('myLazyBox');
 ```
 


### PR DESCRIPTION
It seems as if this page refers to a previous method of handling lazy boxes - fixed to reflect what appears to be the 'correct' method names