### PR TITLE
Update source link to reach the intended repo

### DIFF
--- a/tutorials/favorite_books.md
+++ b/tutorials/favorite_books.md
@@ -6,7 +6,7 @@ In this tutorial we will build a simple app which stores the user's favorite boo
 
 ## Source Code & Live Test
 
-Here's the source: https://github.com/Reprevise/favorite_books
+Here's the source: https://github.com/hivedb/samples/
 
 Below you can find the final code and test the app.
 


### PR DESCRIPTION
The [original link](https://github.com/Reprevise/favorite_books) now reaches a 404, as the repository location has changed.