### PR TITLE
Added WidgetsFlutterBinding.ensureInitialized();

### DIFF
--- a/basics/hive_in_flutter.md
+++ b/basics/hive_in_flutter.md
@@ -19,6 +19,7 @@ import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await Hive.initFlutter();
   await Hive.openBox('settings');
   runApp(MyApp());


### PR DESCRIPTION
This was missing in the documentary. Many people are getting error because they didn't use this function in their code. You can add it.