### PR TITLE
Update encrypted_box.md

### DIFF
--- a/advanced/encrypted_box.md
+++ b/advanced/encrypted_box.md
@@ -2,36 +2,38 @@
 
 Sometimes it is necessary to store data securely on the disk. Hive supports AES-256 encryption out of the box \(literally\).
 
-The only thing you need is a 256-bit \(32 bytes\) encryption key. Hive provides a helper function to generate a secure encryption key using the [Fortuna](https://en.wikipedia.org/wiki/Fortuna_%28PRNG%29) random number generator:
+The only thing you need is a 256-bit \(32 bytes\) encryption key. Hive provides a helper function to generate a secure encryption key using the [Fortuna](https://en.wikipedia.org/wiki/Fortuna_%28PRNG%29) random number generator.
 
 Just pass the key when you open a box:
 
 ```dart:dart:400px
-import 'dart:typed_data';
+import 'dart:convert';
 import 'package:hive/hive.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 void main() async {
-  var keyBox = await Hive.openBox('encryptionKeyBox');
-  if (!keyBox.containsKey('key')) {
+  final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+  var containsEncryptionKey = await secureStorage.containsKey(key: 'key');
+  if (!containsEncryptionKey) {
     var key = Hive.generateSecureKey();
-    keyBox.put('key', key);
+    await secureStorage.write(key: 'key', value: base64UrlEncode(key));
   }
   
-  var key = keyBox.get('key') as Uint8List;
-  print('Encryption key: $key');
+  var encryptionKey = base64Url.decode(await secureStorage.read(key: 'key'));
+  print('Encryption key: $encryptionKey');
 
-  var encryptedBox = await Hive.openBox('vaultBox', encryptionKey: key);
+  var encryptedBox = await Hive.openBox('vaultBox', encryptionCipher: HiveAesCipher(encryptionKey));
   encryptedBox.put('secret', 'Hive is cool');
   print(encryptedBox.get('secret'));
 }
 ```
 
-!> The example above stores the encryption key in an unencrypted box. You should **NEVER** do that.
+
+!> The example above stores the encryption key using the [flutter\_secure\_storage](https://pub.dev/packages/flutter_secure_storage) package, but you can use any package/method you prefer for securely storing the encryption key when your application is closed.
+
 
 ## Important:
-
 * Only values are encrypted while keys are stored in plaintext.
-* Make sure to store the encryption key securely when your application is closed. With Flutter you can use the [flutter\_secure\_storage](https://pub.dev/packages/flutter_secure_storage) or a similar package.
 * There is no check if the encryption key is correct. If it isn't, there may be unexpected behavior.
 
 


### PR DESCRIPTION
Replaces deprecated encryptionKey argument when opening an encrypted box with encryptionCipher, and utilizes flutter_secure_storage to avoid sharing the bad practice of storing the encryption key in an insecure box. flutter_secure_storage was already listed as a solution in the docs, so this uses it for the example code, updating the warning note that alternatives can be used