### PR TITLE
:memo: :pencil2: fixed error in home.md

### DIFF
--- a/home.md
+++ b/home.md
@@ -4,7 +4,7 @@
 
 Add the following to your `pubspec.yaml`:
 
-```version
+```yaml
 dependencies:
   hive: ^[version]
   hive_flutter: ^[version]


### PR DESCRIPTION
yaml code block for dependencies was not being displayed on documentation at https://docs.hivedb.dev/#/README

under

# Quick Start

## Add to project

Add the following to your `pubspec.yaml`: 



because language provided for the code block was "**version**" which is not a valid language :goal_net:

````markdown
```version
dependencies:
  hive: ^[version]
  hive_flutter: ^[version]

dev_dependencies:
  hive_generator: ^[version]
  build_runner: ^[version]
```
````



I changed the language mentioned in the code block to **yaml ** :bug:  :pencil2: :art: :memo:

````markdown
```yaml
dependencies:
  hive: ^[version]
  hive_flutter: ^[version]

dev_dependencies:
  hive_generator: ^[version]
  build_runner: ^[version]
```
````