### PR TITLE
Variable type does not match

### DIFF
--- a/advanced/encrypted_box.md
+++ b/advanced/encrypted_box.md
@@ -22,10 +22,10 @@ void main() async {
       value: base64UrlEncode(key),
     );
   }
-  final key = await secureStorage.read(key: 'key');
-  final encryptionKey = base64Url.decode(key!);
-  print('Encryption key: $encryptionKey');
-  final encryptedBox= await Hive.openBox('vaultBox', encryptionCipher: HiveAesCipher(encryptionKey));
+  encryptionKey = await secureStorage.read(key: 'key');
+  final key = base64Url.decode(encryptionKey!);
+  print('Encryption key: $key');
+  final encryptedBox= await Hive.openBox('vaultBox', encryptionCipher: HiveAesCipher(key));
   encryptedBox.put('secret', 'Hive is cool');
   print(encryptedBox.get('secret'));
 }


### PR DESCRIPTION
This is the "original" code
final key = await secureStorage.read(key: 'key');
final encryptionKey = base64Url.decode(key!);
print('Encryption key: $encryptionKey');
final encryptedBox= await Hive.openBox('vaultBox', encryptionCipher: HiveAesCipher(encryptionKey));
 1- the variable encryptionKey is declared as final on top, so it could not be final
 2- the variable encryptionKey is typed as String? so it does not match with the return of .decode() -> Uint8List
 3- because of these, the example code does not work
I propose this : 
encryptionKey = await secureStorage.read(key: 'key');
  final key = base64Url.decode(encryptionKey!);
  print('Encryption key: $key');
  final encryptedBox= await Hive.openBox('vaultBox', encryptionCipher: HiveAesCipher(key));